### PR TITLE
Fix #1: change mkdocs-material config to set English base link to /

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -78,7 +78,7 @@ plugins:
 extra:
   alternate:
     - name: English
-      link: /en/
+      link: /
       lang: en
     - name: 日本語
       link: /ja/


### PR DESCRIPTION
This is in effort to fix the issue where the language switcher for English on the home page links to `kcmw3e.com/en/` instead of just `kcmw3e.com/` (only occurs when hosted using GitHub pages).

This addresses #1.